### PR TITLE
Add navigation sidebar and header controls

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import './globals.css'
-import ThemeToggle from '@/components/ThemeToggle'
+import Sidebar from '@/components/Sidebar'
+import Header from '@/components/Header'
 
 export const metadata: Metadata = {
   title: 'Social Media Manager',
@@ -10,11 +11,12 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="antialiased min-h-screen">
-        <header className="p-4 flex justify-end">
-          <ThemeToggle />
-        </header>
-        {children}
+      <body className="antialiased min-h-screen flex">
+        <Sidebar />
+        <div className="flex-1 flex flex-col">
+          <Header />
+          <main className="flex-1 p-4">{children}</main>
+        </div>
       </body>
     </html>
   )

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,48 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabase'
+import ThemeToggle from './ThemeToggle'
+
+const agents = ['gpt-3.5-turbo', 'gpt-4']
+
+export default function Header() {
+  const [agent, setAgent] = useState('gpt-3.5-turbo')
+
+  useEffect(() => {
+    const stored = localStorage.getItem('agent')
+    if (stored) setAgent(stored)
+  }, [])
+
+  function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const value = e.target.value
+    setAgent(value)
+    localStorage.setItem('agent', value)
+  }
+
+  async function logout() {
+    await supabase.auth.signOut()
+    window.location.href = '/'
+  }
+
+  return (
+    <header className="p-4 border-b flex items-center justify-between">
+      <div className="flex items-center gap-2">
+        <select
+          value={agent}
+          onChange={handleChange}
+          className="border rounded px-2 py-1"
+        >
+          {agents.map((a) => (
+            <option key={a} value={a}>
+              {a}
+            </option>
+          ))}
+        </select>
+        <ThemeToggle />
+      </div>
+      <button onClick={logout} className="border px-3 py-1 rounded">
+        Logout
+      </button>
+    </header>
+  )
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,33 @@
+'use client'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+const links = [
+  { href: '/', label: 'Home' },
+  { href: '/dashboard', label: 'Dashboard' },
+  { href: '/calendar', label: 'Calendar' },
+]
+
+export default function Sidebar() {
+  const pathname = usePathname()
+
+  return (
+    <aside className="w-48 border-r p-4 min-h-screen">
+      <nav className="space-y-2">
+        {links.map((link) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            className={
+              pathname === link.href
+                ? 'font-semibold'
+                : 'text-gray-600 hover:text-gray-900'
+            }
+          >
+            {link.label}
+          </Link>
+        ))}
+      </nav>
+    </aside>
+  )
+}


### PR DESCRIPTION
## Summary
- implement `Sidebar` navigation component
- implement `Header` with theme toggle, AI agent selection and logout
- revise layout to include sidebar and header

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e0cb647bc8327a6c5024d79068f27