### PR TITLE
Add shadcn buttons and calendar fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project is an MVP SaaS service that helps you plan, create and schedule soc
 ## Getting Started
 
 1. Copy `.env.example` to `.env` and fill in your Supabase credentials and database connection string.
-2. Install dependencies:
+2. Install dependencies (required for components like `react-calendar`):
    ```bash
    npm install
    ```
@@ -41,4 +41,4 @@ This project is ready to deploy on **Vercel**. Ensure the environment variables 
 
 - Social network posting is simulated via a mock function in `src/lib/publisher.ts`.
 - All tables reference the Supabase `auth.users` table by storing the `userId`.
-- The UI is minimal and uses Tailwind CSS utilities; you can extend it with more shadcn/ui components.
+- The UI uses Tailwind CSS utilities and includes shadcn/ui buttons for a better experience.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "prisma": "^6.9.0",
         "react": "^19.0.0",
         "react-calendar": "^6.0.0",
+        "clsx": "^2.1.1",
         "react-dom": "^19.0.0",
         "swr": "^2.3.3",
         "tailwind-merge": "^3.3.1"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "^19.0.0",
     "react-calendar": "^6.0.0",
     "react-dom": "^19.0.0",
+    "clsx": "^2.1.1",
     "swr": "^2.3.3",
     "tailwind-merge": "^3.3.1"
   },

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,6 +1,7 @@
 'use client'
-import Calendar from 'react-calendar'
+import dynamic from 'next/dynamic'
 import 'react-calendar/dist/Calendar.css'
+const Calendar = dynamic(() => import('react-calendar'), { ssr: false })
 import { useState } from 'react'
 import useSWR from 'swr'
 import AIComposer from '@/components/AIComposer'

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,11 +5,25 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --primary: 220 98% 61%;
+  --primary-foreground: 0 0% 100%;
+  --accent: 220 14% 96%;
+  --accent-foreground: 220 98% 40%;
+  --border: 220 13% 91%;
+  --input: 220 13% 91%;
+  --ring: 220 98% 61%;
 }
 
 html.dark {
   --background: #171717;
   --foreground: #ffffff;
+  --primary: 220 98% 61%;
+  --primary-foreground: 0 0% 100%;
+  --accent: 220 14% 16%;
+  --accent-foreground: 220 14% 96%;
+  --border: 220 16% 20%;
+  --input: 220 16% 20%;
+  --ring: 220 98% 61%;
 }
 
 body {

--- a/src/components/AIComposer.tsx
+++ b/src/components/AIComposer.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useState } from 'react'
+import { Button } from '@/components/ui/button'
 
 export default function AIComposer() {
   const [prompt, setPrompt] = useState('')
@@ -32,20 +33,12 @@ export default function AIComposer() {
         placeholder="Describe your post idea"
       />
       <div className="flex gap-2">
-        <button
-          onClick={() => handleGenerate('text')}
-          className="border px-3 py-1 rounded"
-          disabled={loading}
-        >
+        <Button onClick={() => handleGenerate('text')} disabled={loading}>
           AI Text
-        </button>
-        <button
-          onClick={() => handleGenerate('image')}
-          className="border px-3 py-1 rounded"
-          disabled={loading}
-        >
+        </Button>
+        <Button onClick={() => handleGenerate('image')} disabled={loading}>
           AI Image
-        </button>
+        </Button>
       </div>
       {output && <p className="p-2 border rounded">{output}</p>}
       {image && <img src={image} alt="AI result" className="max-w-full border rounded" />}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react'
 import { supabase } from '@/lib/supabase'
 import ThemeToggle from './ThemeToggle'
+import { Button } from '@/components/ui/button'
 
 const agents = ['gpt-3.5-turbo', 'gpt-4']
 
@@ -40,9 +41,9 @@ export default function Header() {
         </select>
         <ThemeToggle />
       </div>
-      <button onClick={logout} className="border px-3 py-1 rounded">
+      <Button variant="outline" onClick={logout}>
         Logout
-      </button>
+      </Button>
     </header>
   )
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -13,15 +13,15 @@ export default function Sidebar() {
 
   return (
     <aside className="w-48 border-r p-4 min-h-screen">
-      <nav className="space-y-2">
+      <nav className="flex flex-col space-y-2">
         {links.map((link) => (
           <Link
             key={link.href}
             href={link.href}
             className={
-              pathname === link.href
+              (pathname === link.href
                 ? 'font-semibold'
-                : 'text-gray-600 hover:text-gray-900'
+                : 'text-gray-600 hover:text-gray-900') + ' block'
             }
           >
             {link.label}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useState, useEffect } from 'react'
+import { Button } from '@/components/ui/button'
 
 export default function ThemeToggle() {
   const [theme, setTheme] = useState<'light' | 'dark'>('light')
@@ -20,8 +21,8 @@ export default function ThemeToggle() {
   }
 
   return (
-    <button onClick={toggle} className="border rounded px-3 py-1">
+    <Button variant="outline" onClick={toggle}>
       {theme === 'light' ? 'Dark' : 'Light'} Mode
-    </button>
+    </Button>
   )
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,45 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <button
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,13 @@ const config: Config = {
       colors: {
         background: 'var(--background)',
         foreground: 'var(--foreground)',
+        primary: 'hsl(var(--primary))',
+        'primary-foreground': 'hsl(var(--primary-foreground))',
+        accent: 'hsl(var(--accent))',
+        'accent-foreground': 'hsl(var(--accent-foreground))',
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
       },
     },
   },


### PR DESCRIPTION
## Summary
- import and use a local shadcn/ui `Button` component
- dynamically load `react-calendar`
- tweak sidebar layout so links stack vertically
- expose theme colors for shadcn buttons
- document installing dependencies

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e1018a3448327946782f27bf53711